### PR TITLE
add latency benchmark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ This mode is supported with Verbs or EFA provider if the following conditions ar
                              List of HCCL process that will open a communicator.
     --no_correctness         Skip correctness validation.
     --reduction_op           <sum|min|max> (default=sum)
+    --latency_benchmark      Enable latency benchmark mode (measures time per iteration).
+
 ### Logging flags
     --result_csv CSV_FILE      Path to a file for results output (optional).
     --ignore_mpi_errors, -ignore_mpi_errors
@@ -277,6 +279,14 @@ Output example:
     262144        65536         float         sum           <time>        <bandwidth>   <bandwidth>
     524288        131072        float         sum           <time>        <bandwidth>   <bandwidth>
     1048576       262144        float         sum           <time>        <bandwidth>   <bandwidth>
+
+### Running HCCL with latency benchmark on 1 server (8 Gaudi devices)
+
+Configuration: One server with 8 ranks, 32 MB size, all_reduce collective, 1000 iterations, latency benchmark mode
+
+    HCCL_COMM_ID=127.0.0.1:5555 python3 run_hccl_demo.py --nranks 8 --node_id 0 --size 32m --test all_reduce --loop 1000 --ranks_per_node 8 --latency_benchmark
+
+**Note**: When latency benchmark mode is enabled, the test measures latency per iteration instead of overall throughput. This is useful for measuring the communication latency of HCCL operations.
 
 ## Examples - MPI mode
 

--- a/common.h
+++ b/common.h
@@ -280,6 +280,11 @@ double benchmark(const EnvData&                       envData,
                  const std::function<void(uint64_t)>& fn,
                  const std::function<void()>&         fnCorrectness);
 
+double benchmark_latency(const EnvData&                       envData,
+                        const DeviceResources&               resources,
+                        const std::function<void(uint64_t)>& fn,
+                        const std::function<void()>&         fnCorrectness);
+
 // demo environmental variables
 EnvData getenvData();
 

--- a/run_hccl_demo.py
+++ b/run_hccl_demo.py
@@ -56,6 +56,7 @@ class DemoTest:
         self.no_correctness           = False
         self.reduction_op             = None
         self.scaleout_bw              = None
+        self.latency_benchmark        = False
         self.default_affinity_dir     = '/tmp/affinity_topology_output'
         self.cmd_list                 = []
         self.log_level                = Logger.DEBUG
@@ -144,6 +145,7 @@ class DemoTest:
         test_group.add_argument("--no_correctness", action="store_true", help="Skip correctness validation.")
         test_group.add_argument("--reduction_op", type=str, help="<sum|min|max> (default=sum)", default="sum")
         test_group.add_argument("--scaleout_bw", type=str, help="Expected scaleout BW in units of G,M,K,B or no unit. Default is Bytes/sec")
+        test_group.add_argument("--latency_benchmark", action="store_true", help="Enable latency benchmark mode (measures latency per iteration instead of overall throughput)")
         # Logging flags
         log_group = parser.add_argument_group('Logging Options')
         log_group.add_argument("--result_csv", type=str, default="",
@@ -296,6 +298,9 @@ class DemoTest:
 
             if self.scaleout_bw:
                 cmd_args.append("HCCL_EXPECTED_SCALEOUT_BW=" + self.parse_size(self.scaleout_bw, is_memory_size=False))
+
+            if self.latency_benchmark:
+                cmd_args.append("HCCL_DEMO_LATENCY_BENCHMARK=1")
 
             cmd_args.append("HCCL_REDUCTION_OP=" + self.reduction_op)
 


### PR DESCRIPTION
This pull request introduces a new latency benchmark mode to the HCCL demo tool, allowing users to measure communication latency per iteration rather than overall throughput. The changes include new CLI options, updates to documentation, and logic to select the appropriate benchmarking method based on user input.

**Latency Benchmark Feature:**

* Added a new CLI flag `--latency_benchmark` to `run_hccl_demo.py` and documented its usage in `README.md`, enabling users to run tests that measure latency per iteration. [[1]](diffhunk://#diff-ab534327b42d62879f59944188de939d500bddb2eb426467ce0c482a97401ac6R148) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R177)
* Updated the command construction in `run_hccl_demo.py` to set the `HCCL_DEMO_LATENCY_BENCHMARK` environment variable when latency benchmarking is enabled.

**Benchmark Logic and Reporting:**

* Implemented the `benchmark_latency` function in `hccl_demo.cpp` to measure and report average latency per iteration, including warmup and correctness validation.
* Modified the collective test driver and test runner in `hccl_demo.cpp` to select between throughput and latency benchmarking based on the new environment variable. [[1]](diffhunk://#diff-70b69f85cae7882d445dd72787116f0d067e5f2607e8a90d6cf1690336c5a9e2L799-R884) [[2]](diffhunk://#diff-70b69f85cae7882d445dd72787116f0d067e5f2607e8a90d6cf1690336c5a9e2R1001-R1008)
* Updated reporting in `hccl_demo.cpp` to distinguish between latency and throughput benchmarks in the summary output. [[1]](diffhunk://#diff-70b69f85cae7882d445dd72787116f0d067e5f2607e8a90d6cf1690336c5a9e2L830-R928) [[2]](diffhunk://#diff-70b69f85cae7882d445dd72787116f0d067e5f2607e8a90d6cf1690336c5a9e2L960-R1056)

**Documentation:**

* Added a usage example and explanation for latency benchmarking in the `README.md`, clarifying its purpose and how to enable it.